### PR TITLE
DTE-710: update SF couple of fields + handling error as status

### DIFF
--- a/templates/step-function-definition.json.tftpl
+++ b/templates/step-function-definition.json.tftpl
@@ -68,7 +68,7 @@
       "Type": "Pass",
       "Next": "SNS Publish tre-internal",
       "Parameters": {
-        "status": "JudgmentParseNoErrors"
+        "status": "JUDGMENT_PARSE_NO_ERRORS"
       },
       "ResultPath": "$.emit-message-parameters"
     },
@@ -76,7 +76,7 @@
       "Type": "Pass",
       "Next": "SNS Publish tre-internal",
       "Parameters": {
-        "status": "JudgmentParseWithErrors"
+        "status": "JUDGMENT_PARSE_WITH_ERRORS"
       },
       "ResultPath": "$.emit-message-parameters"
     },
@@ -111,7 +111,7 @@
       "Choices": [
         {
           "Variable": "$.emit-message-parameters.status",
-          "StringEquals": "JudgmentParseNoErrors",
+          "StringEquals": "JUDGMENT_PARSE_NO_ERRORS",
           "Next": "Parser success -> Slack"
         }
       ],

--- a/templates/step-function-definition.json.tftpl
+++ b/templates/step-function-definition.json.tftpl
@@ -52,22 +52,33 @@
         {
           "Variable": "$.parser-outputs.error-messages[0]",
           "IsPresent": true,
-          "Next": "Name as parser error"
+          "Next": "Prepare parser error parameters"
+        },
+        {
+          "Not": {
+            "Variable": "$.parser-outputs.error-messages",
+            "IsPresent": true
+          },
+          "Next": "Unexpected Parser Output -> Slack"
         }
       ],
-      "Default": "Name as parser success"
+      "Default": "Prepare parser success parameters"
     },
-    "Name as parser success": {
+    "Prepare parser success parameters": {
       "Type": "Pass",
       "Next": "SNS Publish tre-internal",
-      "Result": "uk.gov.nationalarchives.tre.messages.judgment.parse.JudgmentParse",
-      "ResultPath": "$.emit-message-type"
+      "Parameters": {
+        "status": "JudgmentParseNoErrors"
+      },
+      "ResultPath": "$.emit-message-parameters"
     },
-    "Name as parser error": {
+    "Prepare parser error parameters": {
       "Type": "Pass",
       "Next": "SNS Publish tre-internal",
-      "Result": "uk.gov.nationalarchives.tre.messages.judgment.parse.JudgmentParseError",
-      "ResultPath": "$.emit-message-type"
+      "Parameters": {
+        "status": "JudgmentParseWithErrors"
+      },
+      "ResultPath": "$.emit-message-parameters"
     },
     "SNS Publish tre-internal": {
       "Type": "Task",
@@ -75,15 +86,16 @@
       "Parameters": {
         "Message": {
           "properties": {
-            "messageType.$": "$.emit-message-type",
-            "timestampMillis.$": "$$.State.EnteredTime",
+            "messageType": "uk.gov.nationalarchives.tre.messages.judgment.parse.JudgmentParse",
+            "timestamp.$": "$$.State.EnteredTime",
             "function": "tre-tf-module-parse-judgment",
             "producer": "TRE",
             "executionId.$": "$.properties.executionId",
             "parentExecutionId.$": "$.properties.parentExecutionId"
           },
           "parameters": {
-            "originator": "FCL",
+            "status.$": "$.emit-message-parameters.status",
+            "originator.$": "$.parameters.originator",
             "s3FolderName.$": "States.Format('consignments/judgment/FCL/{}/{}/', $.parameters.reference, $.properties.executionId)",
             "s3Bucket": "${tre_data_bucket}",
             "reference.$": "$.parameters.reference"
@@ -98,8 +110,8 @@
       "Type": "Choice",
       "Choices": [
         {
-          "Variable": "$.emit-message-type",
-          "StringEquals": "uk.gov.nationalarchives.tre.messages.judgment.parse.JudgmentParse",
+          "Variable": "$.emit-message-parameters.status",
+          "StringEquals": "JudgmentParseNoErrors",
           "Next": "Parser success -> Slack"
         }
       ],
@@ -121,6 +133,21 @@
     },
     "Success": {
       "Type": "Succeed"
+    },
+    "Unexpected Parser Output -> Slack": {
+      "Type": "Task",
+      "Resource": "arn:aws:states:::sns:publish",
+      "Parameters": {
+        "TopicArn": "{arn_sns_topic_tre_slack_alerts}",
+        "Message": {
+          "Execution.$": "$$.Execution.Name",
+          "StateMachine.$": "$$.StateMachine.Name",
+          "Status": "error",
+          "ErrorMessage": null,
+          "Event": "Unexpected Output (Parse Judgment)"
+        }
+      },
+      "Next": "Parse Judgment Failed"
     },
     "Parse Judgment Lambda Error -> Slack": {
       "Type": "Task",

--- a/tests/test-script/module_sns_msg.sh
+++ b/tests/test-script/module_sns_msg.sh
@@ -3,15 +3,16 @@ set -e
 
 main() {
   if [ $# -lt 2 ] || [ $# -gt 5 ]; then
-    echo "Usage: sns_arn aws_profile_target [aws_profile_source] [s3_bucket_source] [ps3_object_docx]"
+    echo "Usage: sns_arn aws_profile_target [aws_profile_source] [ps3_object_docx] [s3_bucket_source]"
     return 1
   fi
 
   local sns_arn="${1:?}"
   local aws_profile_target="${2:?}"
-  local aws_profile_source="${3:-""}"
-  local s3_bucket_source="${4:-""}"
-  local s3_object_docx="${5:-""}"
+  local s3_object_docx="${3:-""}"
+  local aws_profile_source="${4:-""}"
+  local s3_bucket_source="${5:-""}"
+
 
   printf 'sns_arn="%s"\n' "${sns_arn}"
   printf 'aws_profile_target="%s"\n' "${aws_profile_target}"
@@ -22,7 +23,8 @@ main() {
   if [ "$s3_bucket_source" = "" ]
   then
           printf "Using Default docx"
-          docx_url="https://tna-caselaw-assets.s3.eu-west-2.amazonaws.com/eat/2022/1/eat_2022_1.docx"
+          docx_url=${s3_object_docx}
+# test doc not found with this change
 #          docx_url="https://tre-testing"
   else
           local s3_path_docx="s3://${s3_bucket_source}/${s3_object_docx}"
@@ -33,6 +35,7 @@ main() {
               --expires-in "${presigned_url_expiry_secs:-60}")"
   fi
   printf 'docx_url="%s"\n' "${docx_url}"
+# test presigned url has timedout with a sleep here
 #  sleep 2m
   local test_uuid
   test_uuid="$(uuidgen | tr '[:upper:]' '[:lower:]')"

--- a/tests/test-script/module_sns_msg.sh
+++ b/tests/test-script/module_sns_msg.sh
@@ -23,6 +23,7 @@ main() {
   then
           printf "Using Default docx"
           docx_url="https://tna-caselaw-assets.s3.eu-west-2.amazonaws.com/eat/2022/1/eat_2022_1.docx"
+#          docx_url="https://tre-testing"
   else
           local s3_path_docx="s3://${s3_bucket_source}/${s3_object_docx}"
           printf 'AWS S3 listing for source docx "%s":\n' "${s3_path_docx:?}"
@@ -32,7 +33,7 @@ main() {
               --expires-in "${presigned_url_expiry_secs:-60}")"
   fi
   printf 'docx_url="%s"\n' "${docx_url}"
-
+#  sleep 2m
   local test_uuid
   test_uuid="$(uuidgen | tr '[:upper:]' '[:lower:]')"
 

--- a/tests/test-script/sns-msg.json
+++ b/tests/test-script/sns-msg.json
@@ -1,14 +1,14 @@
 {
   "properties" : {
     "messageType" : "uk.gov.nationalarchives.tre.messages.judgment.parse.RequestJudgmentParse",
-    "timestampMillis" : "2023-03-29T11:00:12.280Z",
+    "timestamp" : "2023-03-29T11:00:12.280Z",
     "function" : "fcl-judgment-parse-request",
     "producer" : "FCL",
     "executionId" : "XXX_uuid_XXX",
     "parentExecutionId" : null
   },
   "parameters": {
-    "reference": "FCL-MK-23",
+    "reference": "FCL-MK-102",
     "judgmentURI": "XXX_docx_url_XXX",
     "originator" : "FCL"
   }


### PR DESCRIPTION
change to `timestamp` and add new error catching path for DTE-680 if returned parser output not firmed as expected for error field
change so that emits error in status field for DTE-721 
@ian-hoyle are you happy with naming in emum of status as:
`JudgmentParseNoErrors` or `JudgmentParseWithErrors`
Note that currently only publish to SNS in these two "success" cases.  Cases of "lamdba failure etc" just marked as SF failure with notify to slack for human attention.

 
