### PR TITLE
DTE-744: sf fix naming in status fields + update test script

### DIFF
--- a/templates/step-function-definition.json.tftpl
+++ b/templates/step-function-definition.json.tftpl
@@ -71,7 +71,7 @@
       "Type": "Pass",
       "Next": "SNS Publish tre-internal",
       "Parameters": {
-        "status": "JUDGMENT_PARSE_NO_ERRORS"
+        "status": "COURT_DOCUMENT_PARSE_NO_ERRORS"
       },
       "ResultPath": "$.emit-message-parameters"
     },
@@ -79,7 +79,7 @@
       "Type": "Pass",
       "Next": "SNS Publish tre-internal",
       "Parameters": {
-        "status": "JUDGMENT_PARSE_WITH_ERRORS"
+        "status": "COURT_DOCUMENT_PARSE_WITH_ERRORS"
       },
       "ResultPath": "$.emit-message-parameters"
     },
@@ -156,7 +156,7 @@
       "Choices": [
         {
           "Variable": "$.emit-message-parameters.status",
-          "StringEquals": "JUDGMENT_PARSE_NO_ERRORS",
+          "StringEquals": "COURT_DOCUMENT_PARSE_NO_ERRORS",
           "Next": "Parser success -> Slack"
         }
       ],

--- a/tests/test-script/README.md
+++ b/tests/test-script/README.md
@@ -1,12 +1,5 @@
 
-A test msg is sent to trigger the module. THe messge `sns-msg.json` has a docx_url and a uuid substituted before being
+A test msg is sent to trigger the module. The message `sns-msg.json` has a source bucket + source key and a uuid substituted before being
 put on the "sns_arn" topic in the "aws_profile_target".
 
-Use an availaible public docx_url or use optional params "aws_profile_source" & "s3_bucket_source"
-to have one made.
-
-with a public docx url use:
-`./module_sns_msg.sh tre-in-arn tre-non-prod-user s3_object_docx`
-
-or to make a presigned url for the docx (there is one for example in dev-te-testdata) use:
-`./module_sns_msg.sh tre-in-arn tre-non-prod-user da-transform-sample-data/test-judgments/test.docx tre-management-user dev-te-testdata`
+`./module_sns_msg.sh tre-in-arn tre-non-prod-user s3_source_bucket s3_source_key`

--- a/tests/test-script/module_sns_msg.sh
+++ b/tests/test-script/module_sns_msg.sh
@@ -2,48 +2,27 @@
 set -e
 
 main() {
-  if [ $# -lt 2 ] || [ $# -gt 5 ]; then
-    echo "Usage: sns_arn aws_profile_target s3_object_docx [aws_profile_source] [s3_bucket_source]"
+  if [ $# -lt 4 ] || [ $# -gt 4 ]; then
+    echo "Usage: sns_arn aws_profile_target s3_bucket_source s3_key_source"
     return 1
   fi
 
   local sns_arn="${1:?}"
   local aws_profile_target="${2:?}"
-  local s3_object_docx="${3:-""}"
-  local aws_profile_source="${4:-""}"
-  local s3_bucket_source="${5:-""}"
-
+  local s3_bucket_source="${3:?}"
+  local s3_key_source="${4:?}"
 
   printf 'sns_arn="%s"\n' "${sns_arn}"
   printf 'aws_profile_target="%s"\n' "${aws_profile_target}"
-  printf 'aws_profile_source="%s"\n' "${aws_profile_source}"
 
-  local docx_url
-  #if no bucket source (and no s3 object docx) then use default, otherwise make a presigned url for docx
-  if [ "$s3_bucket_source" = "" ]
-  then
-          printf "Using Default docx"
-          docx_url=${s3_object_docx}
-# test doc not found with this change
-#          docx_url="https://tre-testing"
-  else
-          local s3_path_docx="s3://${s3_bucket_source}/${s3_object_docx}"
-          printf 'AWS S3 listing for source docx "%s":\n' "${s3_path_docx:?}"
-          aws --profile "${aws_profile_source}" s3 ls "${s3_path_docx}"
-          docx_url="$(aws --profile "${aws_profile_source}" \
-              s3 presign "s3://${s3_bucket_source}/${s3_object_docx}" \
-              --expires-in "${presigned_url_expiry_secs:-60}")"
-  fi
-  printf 'docx_url="%s"\n' "${docx_url}"
-# test presigned url has timedout with a sleep here
-#  sleep 2m
   local test_uuid
   test_uuid="$(uuidgen | tr '[:upper:]' '[:lower:]')"
 
   message_string=$(cat sns-msg.json)
-  message_string_with_url="${message_string/XXX_docx_url_XXX/$docx_url}"
-  message_string_with_url_and_uuid="${message_string_with_url/XXX_uuid_XXX/$test_uuid}"
-  msg_to_publish="${message_string_with_url_and_uuid}"
+  message_string_with_bucket="${message_string/XXX_bucket_XXX/$s3_bucket_source}"
+  message_string_with_bucket_and_key="${message_string_with_bucket/XXX_key_XXX/$s3_key_source}"
+  message_string_with_bucket_and_key_and_uuid="${message_string_with_bucket_and_key/XXX_uuid_XXX/$test_uuid}"
+  msg_to_publish="${message_string_with_bucket_and_key_and_uuid}"
 
   printf 'Publishing Message:\n%s\n' "${msg_to_publish:?}"
   aws --profile "${aws_profile_target:?}" sns publish \

--- a/tests/test-script/sns-msg.json
+++ b/tests/test-script/sns-msg.json
@@ -1,15 +1,19 @@
 {
   "properties" : {
-    "messageType" : "uk.gov.nationalarchives.tre.messages.judgment.parse.RequestJudgmentParse",
+    "messageType" : "uk.gov.nationalarchives.tre.messages.request.courtdocument.parse.RequestCourtDocumentParse",
     "timestamp" : "2023-03-29T11:00:12.280Z",
-    "function" : "fcl-judgment-parse-request",
+    "function" : "fcl-court-document-parse-request",
     "producer" : "FCL",
     "executionId" : "XXX_uuid_XXX",
     "parentExecutionId" : null
   },
   "parameters": {
-    "reference": "FCL-MK-102",
-    "judgmentURI": "XXX_docx_url_XXX",
-    "originator" : "FCL"
+    "s3Bucket" : "XXX_bucket_XXX",
+    "s3Key" : "XXX_key_XXX",
+    "reference" : "FCL-MK-1",
+    "originator" : "FCL",
+    "parserInstructions" : {
+      "documentType" : "judgment"
+    }
   }
 }


### PR DESCRIPTION
- use status of type: `COURT_DOCUMENT_PARSE_NO_ERRORS`
- update dev testing script to take bucket and key instead of presigned url 
- still some more judgments to update, but keeping it to these for purposes of ready for FCL